### PR TITLE
Update depends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ scopeguard = "1.1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 netlink-sys = "0.8.3"
-netlink-packet-route = "0.24.0"
-netlink-packet-core = "0.7.0"
+netlink-packet-route = "0.25.1"
+netlink-packet-core = "0.8.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-system-configuration-sys = "0.5.0"
-core-foundation = "0.9.3"
+system-configuration-sys = "0.6.0"
+core-foundation = "0.10.1"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.30.1", features = ["ioctl", "net"] }

--- a/src/sys/darwin/handle.rs
+++ b/src/sys/darwin/handle.rs
@@ -1,4 +1,4 @@
-use super::scinterface::SCNetworkInterface;
+use crate::sys::scinterface::SCNetworkInterface;
 use crate::sys::{dummy_socket, ioctls, InterfaceHandle};
 use crate::sys::{ifreq, InterfaceName};
 use crate::{Error, Interface};

--- a/src/sys/darwin/scinterface.rs
+++ b/src/sys/darwin/scinterface.rs
@@ -4,6 +4,7 @@ use system_configuration_sys::network_configuration::{
     SCNetworkInterfaceCopyAll, SCNetworkInterfaceGetBSDName,
     SCNetworkInterfaceGetLocalizedDisplayName, SCNetworkInterfaceGetTypeID, SCNetworkInterfaceRef,
 };
+use core_foundation::declare_TCFType;
 
 core_foundation::declare_TCFType!(SCNetworkInterface, SCNetworkInterfaceRef);
 core_foundation::impl_TCFType!(


### PR DESCRIPTION
Current version has an issue by cargo audit.

```
Crate:     paste
Version:   1.0.15
Warning:   unmaintained
Title:     paste - no longer maintained
Date:      2024-10-07
ID:        RUSTSEC-2024-0436
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0436
Dependency tree:
paste 1.0.15
├── netlink-packet-utils 0.5.2
│   ├── netlink-packet-route 0.24.0
│   │   ├── route_manager 0.2.9
│   │   │   └── tun-rs 2.7.3
│   │   └── netconfig-rs 0.1.5
│   │       └── tun-rs 2.7.3
│   └── netlink-packet-core 0.7.0
│       ├── route_manager 0.2.9
│       ├── netlink-packet-route 0.24.0
│       └── netconfig-rs 0.1.5
└── netlink-packet-core 0.8.1
    ├── netlink-packet-route 0.25.1
    │   └── netconfig-rs 0.1.5
    └── netconfig-rs 0.1.5
```